### PR TITLE
Packet::read/writeLength: optimize bytes written to stream to reduce bandwidth

### DIFF
--- a/network/include/rawrbox/network/packet.hpp
+++ b/network/include/rawrbox/network/packet.hpp
@@ -16,13 +16,13 @@ namespace rawrbox {
 	// CONCEPTS ----
 	template <typename T>
 	concept isNetworkReadable = requires(T t, rawrbox::Packet p) {
-					    { t.networkRead(p) };
-				    };
+		{ t.networkRead(p) };
+	};
 
 	template <typename T>
 	concept isNetworkWritable = requires(T t, rawrbox::Packet p) {
-					    { t.networkWrite(p) };
-				    };
+		{ t.networkWrite(p) };
+	};
 	// ----------------
 
 	class Packet {

--- a/network/include/rawrbox/network/packet.hpp
+++ b/network/include/rawrbox/network/packet.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdint.h>
+
 #include <algorithm>
 #include <bit>
 #include <cstdint>
@@ -118,13 +120,13 @@ namespace rawrbox {
 
 		template <class T = size_t>
 		T readLength() {
-			constexpr auto maskNum = 0x7F;
-			constexpr auto maskFlag = 0x80;
+			constexpr uint64_t maskNum = 0x7F;
+			constexpr uint64_t maskFlag = 0x80;
 
-			size_t ret = 0;
-			size_t bitsReceived = 0;
+			uint64_t ret = 0;
+			uint64_t bitsReceived = 0;
 			while (true) {
-				auto byte = read<uint8_t>();
+				uint64_t byte = read<uint8_t>();
 
 				ret = ret | ((byte & maskNum) << bitsReceived);
 				bitsReceived += 7;
@@ -216,21 +218,20 @@ namespace rawrbox {
 				return;
 			}
 
-			auto maxLen = static_cast<size_t>(size);
-			uint8_t maskNum = 0x7F;
-			uint8_t maskFlag = 0x80;
-			while (maxLen > 0) {
-				bool hasMore = (maxLen >> 7) > 0;
-				write(static_cast<uint8_t>((maxLen & maskNum) | (hasMore ? maskFlag : 0x00)));
+			auto remaining = static_cast<size_t>(size);
+			constexpr uint64_t maskNum = 0x7F;
+			constexpr uint64_t maskFlag = 0x80;
 
-				maxLen >>= 7;
+			while (remaining > 0) {
+				bool hasMore = (remaining >> 7) > 0;
+				write(static_cast<uint8_t>((remaining & maskNum) | (hasMore ? maskFlag : 0x00ULL)));
+
+				remaining >>= 7;
 			}
 		}
 		// -----------------
 
 		// UTILS -----
-		void setlengthFormat(LengthType format);
-
 		bool seek(size_t offset);
 		bool seek(std::vector<uint8_t>::iterator offset);
 

--- a/network/include/rawrbox/network/packet.hpp
+++ b/network/include/rawrbox/network/packet.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <stdint.h>
-
 #include <algorithm>
 #include <bit>
 #include <cstdint>

--- a/network/src/packet.cpp
+++ b/network/src/packet.cpp
@@ -50,10 +50,6 @@ namespace rawrbox {
 	// --------
 
 	// UTILS -----
-	void Packet::setlengthFormat(LengthType format) {
-		this->lengthFormat = format;
-	}
-
 	bool Packet::seek(size_t offset) {
 		if (offset > size()) return false;
 		this->pos = offset;


### PR DESCRIPTION
### Description

By optimizing the bytes we will change an `int64` value of `41` to just a single byte instead of `8` inside the packet class.
Usually you'd write a `vector.size()` or `array.size()` which is a `uint64_t` of `8` bytes, which most often does not go above the range of `uint32_t` of `4` bytes. Most cases we'd save over `50%` of data per size written.

Each number is written per 7 bits, using the highest last bit to indicate if there's still more data to be received

```c++
rawrbox::Packet p;
p.writeLength(0x00); // 1 byte
p.writeLength(0x7F); // 1 byte
p.writeLength(0xFF);  // 2 bytes
p.writeLength(0x7FFF); // 2 bytes
p.writeLength(0xFFFF); // 3 bytes
p.writeLength(0x7FFFFFFF); // 4 bytes
p.writeLength(0xFFFFFFFF); // 5 bytes
p.writeLength(0x7FFFFFFFFFFFFFFF); //8 bytes
p.writeLength(0xFFFFFFFFFFFFFFFF); // 9 bytes
```