### PR TITLE
Use texture array slices for animated textures

### DIFF
--- a/rawrbox.math/include/rawrbox/math/color.hpp
+++ b/rawrbox.math/include/rawrbox/math/color.hpp
@@ -16,7 +16,8 @@ namespace rawrbox {
 		NumberType r = 0, g = 0, b = 0, a = 1;
 
 		Color_t() = default;
-		constexpr Color_t(NumberType _r, NumberType _g, NumberType _b, NumberType _a) : r(_r), g(_g), b(_b), a(_a) {}
+		constexpr Color_t(NumberType _r, NumberType _g, NumberType _b, NumberType _a = 1) : r(_r), g(_g), b(_b), a(_a) {}
+		constexpr Color_t(const std::array<NumberType, 4>& arr) : r(arr[0]), g(arr[1]), b(arr[2]), a(arr[3]) {}
 
 		static Color_t<NumberType> RGBAHex(uint32_t x) {
 			if constexpr (std::is_same_v<NumberType, float> || std::is_same_v<NumberType, double>) {

--- a/rawrbox.render/assets/shaders/include/bindless/pixel_bindless_uniforms.fxh
+++ b/rawrbox.render/assets/shaders/include/bindless/pixel_bindless_uniforms.fxh
@@ -2,14 +2,20 @@
 #define INCLUDED_PIXEL_UNIFORMS
 
 struct ConstantsStruct {
-	uint4 textureIDs;
+	uint4 textureIDs; // BASE, NORMAL, ROUGHTMETAL, EMISSION
 	float4 litData;
 };
 
 ConstantBuffer<ConstantsStruct> Constants;
 
+#define BaseID          Constants.textureIDs.x
+#define NormalID        Constants.textureIDs.y
+#define RoughtMetalID   Constants.textureIDs.z
+#define EmissionID      Constants.textureIDs.w
+
 #define RoughnessFactor Constants.litData.x
 #define MetalnessFactor Constants.litData.y
 #define SpecularFactor  Constants.litData.z
 #define EmissionFactor  Constants.litData.w
+
 #endif

--- a/rawrbox.render/assets/shaders/include/bindless/vertex_bindless_uniforms.fxh
+++ b/rawrbox.render/assets/shaders/include/bindless/vertex_bindless_uniforms.fxh
@@ -2,30 +2,30 @@
 #define INCLUDED_VERTEX_UNIFORMS
 
 #ifdef SKINNED
-struct SkinnedConstantsStruct {
-	// Model Bones ----
-	float4x4 bones[MAX_BONES_PER_MODEL];
-	// ----------------
-};
+	struct SkinnedConstantsStruct {
+		// Model Bones ----
+		float4x4 bones[MAX_BONES_PER_MODEL];
+		// ----------------
+	};
+
+	ConstantBuffer<SkinnedConstantsStruct> SkinnedConstants;
 #endif
 
 struct ConstantsStruct {
-	// Model ----
-	float4 colorOverride;
-	float4 data;
-	// ----------------
-
-	float4 gpuID;
+	uint4 data;
+	float4 dataF;
 };
 
-#ifdef SKINNED
-ConstantBuffer<SkinnedConstantsStruct> SkinnedConstants;
-#endif
 
 ConstantBuffer<ConstantsStruct> Constants;
 
-#define Billboard           (uint) Constants.data.x
-#define VertexSnap          Constants.data.y
-#define DisplacementTexture (uint) Constants.data.z
-#define DisplacementPower   Constants.data.w
+#define ColorOverride       Constants.data.x
+#define SliceOverride       Constants.data.y
+#define GPUID               Constants.data.z
+#define Billboard           Constants.data.w
+
+#define VertexSnap          Constants.dataF.x
+#define DisplacementTexture (uint) Constants.dataF.y
+#define DisplacementPower   Constants.dataF.z
+
 #endif

--- a/rawrbox.render/assets/shaders/include/unpack.fxh
+++ b/rawrbox.render/assets/shaders/include/unpack.fxh
@@ -61,6 +61,11 @@ float4 Unpack_ARGB8_UNORM(uint value) {
 	return float4(packed.y, packed.z, packed.w, packed.x) / 255.0;
 }
 
+float4 Unpack_ABGR8_UNORM(uint value) {
+    uint4 packed = uint4(value & 0xff, (value >> 8) & 0xff, (value >> 16) & 0xff, value >> 24);
+	return float4(packed.w, packed.z, packed.y, packed.x) / 255.0;
+}
+
 uint Pack_RGBA8_SNORM(float4 value) {
 	int4 packed = int4(round(clamp(value, -1.0, 1.0) * 127.0)) & 0xff;
 	return uint(packed.x | (packed.y << 8) | (packed.z << 16) | (packed.w << 24));

--- a/rawrbox.render/assets/shaders/materials/3Dtext/3dtext_unlit.psh
+++ b/rawrbox.render/assets/shaders/materials/3Dtext/3dtext_unlit.psh
@@ -15,7 +15,7 @@ struct PSOutput {
 };
 
 void main(in PSInput PSIn, out PSOutput PSOut) {
-	float a = g_Textures[Constants.textureIDs.x].Sample(g_Sampler, float3(PSIn.UV, 0)).r * PSIn.Color.a;
+	float a = g_Textures[BaseID].Sample(g_Sampler, float3(PSIn.UV, 0)).r * PSIn.Color.a;
 	if (a <= 0.0) discard;
 
 	PSOut.Color = float4(PSIn.Color.rgb, a);

--- a/rawrbox.render/assets/shaders/materials/3Dtext/3dtext_unlit.vsh
+++ b/rawrbox.render/assets/shaders/materials/3Dtext/3dtext_unlit.vsh
@@ -1,5 +1,6 @@
 #include "camera.fxh"
 #include "vertex_bindless_uniforms.fxh"
+#include "unpack.fxh"
 
 #define TRANSFORM_BILLBOARD
 #include "model_transforms.fxh"
@@ -20,5 +21,5 @@ void main(in VSInput VSIn, out PSInput PSIn) {
 	PSIn.Pos = transform.final;
 
 	PSIn.UV = VSIn.UV.xy;
-	PSIn.Color = Constants.colorOverride;
+	PSIn.Color = Unpack_RGBA8_UNORM(ColorOverride);
 }

--- a/rawrbox.render/assets/shaders/materials/model/lit/lit.psh
+++ b/rawrbox.render/assets/shaders/materials/model/lit/lit.psh
@@ -58,18 +58,18 @@ float3 TangentSpaceNormalMapping(float3 sampledNormal, float3x3 TBN) {
 }
 
 void main(in PSInput PSIn, out PSOutput PSOut) {
-	float4 baseColor = g_Textures[Constants.textureIDs.x].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
+	float4 baseColor = g_Textures[BaseID].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
 	if (baseColor.a <= 0.0) discard;
 
 	if (TOTAL_DECALS != 0 || TOTAL_LIGHTS != 0) {
 		// NORMAL -----
-		float3 normalTS = g_Textures[Constants.textureIDs.y].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)).rgb;
+		float3 normalTS = g_Textures[NormalID].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)).rgb;
 		float3x3 TBN = CreateTangentToWorld(PSIn.Normal.xyz, float4(PSIn.Tangent.xyz, PSIn.Tangent.w));
 		float3 normal = TangentSpaceNormalMapping(normalTS, TBN);
 		// -------------
 
 		// ROUGHT / METAL -----
-		float2 roughtMetalTS = g_Textures[Constants.textureIDs.z].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)).bg;
+		float2 roughtMetalTS = g_Textures[RoughtMetalID].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)).bg;
 		float metal = MetalnessFactor;
 		float rough = RoughnessFactor;
 
@@ -79,7 +79,7 @@ void main(in PSInput PSIn, out PSOutput PSOut) {
 		}
 		// -------------
 
-		float4 emissionTS = g_Textures[Constants.textureIDs.w].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
+		float4 emissionTS = g_Textures[EmissionID].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
 
 		// LIGHT ------
 		float3 V = normalize(Camera.pos - PSIn.WorldPos.xyz);

--- a/rawrbox.render/assets/shaders/materials/model/unlit/unlit.psh
+++ b/rawrbox.render/assets/shaders/materials/model/unlit/unlit.psh
@@ -35,7 +35,7 @@ struct PSOutput {
 };
 
 void main(in PSInput PSIn, out PSOutput PSOut) {
-	float4 color = g_Textures[Constants.textureIDs.x].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
+	float4 color = g_Textures[BaseID].Sample(g_Sampler, float3(PSIn.UV, PSIn.TexIndex)) * PSIn.Color;
 	if (color.a <= 0.0) discard;
 
 #ifdef CLUSTER_PLUGIN

--- a/rawrbox.render/assets/shaders/materials/model/unlit/unlit.vsh
+++ b/rawrbox.render/assets/shaders/materials/model/unlit/unlit.vsh
@@ -1,5 +1,6 @@
 #include "camera.fxh"
 #include "vertex_bindless_uniforms.fxh"
+#include "unpack.fxh"
 
 #define TRANSFORM_DISPLACEMENT
 #define TRANSFORM_PSX
@@ -27,8 +28,8 @@ struct VSInput {
 	float4 MtrxRow1 : ATTRIB5;
 	float4 MtrxRow2 : ATTRIB6;
 	float4 MtrxRow3 : ATTRIB7;
-	float4 ColorOverride : ATTRIB8;
-	float4 Extra : ATTRIB9;
+
+	uint4  InstData : ATTRIB8;  // Color, slice, gpu id, ??
 	#endif
 #else
 	#ifdef INSTANCED
@@ -37,8 +38,8 @@ struct VSInput {
 	float4 MtrxRow1 : ATTRIB3;
 	float4 MtrxRow2 : ATTRIB4;
 	float4 MtrxRow3 : ATTRIB5;
-	float4 ColorOverride : ATTRIB6;
-	float4 Extra : ATTRIB7;
+
+	uint4  InstData : ATTRIB6; // Color, slice, gpu id, ??
 	#endif
 #endif
 };
@@ -73,12 +74,12 @@ void main(in VSInput VSIn, out PSInput PSIn) {
 	PSIn.UV = VSIn.UV.xy;
 
 #ifdef INSTANCED
-	PSIn.Color = VSIn.ColorOverride * Constants.colorOverride;
-	PSIn.GPUId = float4(VSIn.Extra.xyz, 1.);
-	PSIn.TexIndex = VSIn.Extra.w;
+	PSIn.Color = Unpack_RGBA8_UNORM(VSIn.InstData.x) * Unpack_RGBA8_UNORM(ColorOverride);
+	PSIn.TexIndex = VSIn.UV.z + VSIn.InstData.y + SliceOverride;
+	PSIn.GPUId = Unpack_ABGR8_UNORM(VSIn.InstData.z);
 #else
-	PSIn.Color = Constants.colorOverride;
-	PSIn.GPUId = Constants.gpuID;
-	PSIn.TexIndex = VSIn.UV.z;
+	PSIn.Color = Unpack_RGBA8_UNORM(ColorOverride);
+	PSIn.GPUId = Unpack_ABGR8_UNORM(GPUID);
+	PSIn.TexIndex = VSIn.UV.z + SliceOverride;
 #endif
 }

--- a/rawrbox.render/assets/shaders/quad/quad.psh
+++ b/rawrbox.render/assets/shaders/quad/quad.psh
@@ -13,7 +13,7 @@ struct PSOutput {
 };
 
 void main(in PSInput PSIn, out PSOutput PSOut) {
-	float4 color = g_Textures[Constants.textureIDs.x].Sample(g_Sampler, float3(PSIn.UV.xy, 0));
+	float4 color = g_Textures[BaseID].Sample(g_Sampler, float3(PSIn.UV.xy, 0));
 	if (color.a <= 0.0) discard;
 
 	PSOut.Color = color;

--- a/rawrbox.render/include/rawrbox/render/bindless.hpp
+++ b/rawrbox.render/include/rawrbox/render/bindless.hpp
@@ -12,15 +12,11 @@
 namespace rawrbox {
 	struct BindlessVertexBuffer {
 		// MODEL ---
-		rawrbox::Colorf colorOverride = {};
-		rawrbox::Vector4f data = {};
-		// ----------
+		rawrbox::Vector4u data = {0xFFFFFFFF, 0, 0x00000000, 0}; // Color, Atlas, GPUId, Billboard
+		rawrbox::Vector4f dataF = {};                            // VertexSnap, DisplacementTexture, DisplacementPower, ???
+									 // ----------
 
-		// MODEL ID ---
-		rawrbox::Vector4f gpuID = {};
-		// ----------
-
-		bool operator==(const BindlessVertexBuffer& other) const { return this->colorOverride == other.colorOverride && this->data == other.data && this->gpuID == other.gpuID; }
+		bool operator==(const BindlessVertexBuffer& other) const { return this->data == other.data && this->dataF == other.dataF; }
 		bool operator!=(const BindlessVertexBuffer& other) const { return !operator==(other); }
 	};
 

--- a/rawrbox.render/include/rawrbox/render/materials/base.hpp
+++ b/rawrbox.render/include/rawrbox/render/materials/base.hpp
@@ -46,15 +46,12 @@ namespace rawrbox {
 		template <typename T = rawrbox::VertexData>
 			requires(std::derived_from<T, rawrbox::VertexData>)
 		rawrbox::BindlessVertexBuffer bindBaseUniforms(const rawrbox::Mesh<T>& mesh) {
-			std::array<float, 4> gpuID = {0, 0, 0, 0};
-			if (mesh.getID() != 0x00000000) {
-				gpuID = rawrbox::PackUtils::fromRGBA(mesh.getID());
-			}
+			auto* texture = mesh.getTexture();
+			auto* displacement = mesh.getDisplacementTexture();
 
 			return {
-			    mesh.color,
-			    mesh.data.getData(),
-			    gpuID};
+			    {mesh.color.pack(), mesh.getSlice() + (texture == nullptr ? 0U : texture->getSlice()), mesh.getID(), mesh.data.billboard},
+			    {mesh.data.vertexSnapPower, displacement != nullptr ? static_cast<float>(displacement->getTextureID()) : 0.F, mesh.data.displacementPower}};
 		}
 
 		template <typename T = rawrbox::VertexData>

--- a/rawrbox.render/include/rawrbox/render/models/instance.hpp
+++ b/rawrbox.render/include/rawrbox/render/models/instance.hpp
@@ -7,34 +7,24 @@
 namespace rawrbox {
 	struct Instance {
 		rawrbox::Matrix4x4 matrix = {};
-		uint32_t color = 0xFFFFFFFF;
-		rawrbox::Vector4f extraData = {}; // AtlasID, etc..
+		rawrbox::Vector4u data = {0xFFFFFFFF, 0, 0, 0}; // Color, slice, gpu id, ??
 
 		Instance() = default;
-		Instance(const rawrbox::Matrix4x4& mat, const rawrbox::Colorf& col = rawrbox::Colors::White(), uint16_t atlasId = 0, uint32_t id = 0) : matrix(mat), color(col.pack()) {
-			this->setAtlasId(atlasId);
+		Instance(const rawrbox::Matrix4x4& mat, const rawrbox::Colorf& col = rawrbox::Colors::White(), uint16_t slice = 0, uint32_t id = 0) : matrix(mat), data(col.pack(), 0, 0, 0) {
+			this->setSlice(slice);
 			if (id != 0) this->setId(id);
 		}
 
-		[[nodiscard]] rawrbox::Colorf getColor() const { return rawrbox::Color::RGBAHex(color); }
-		void setColor(const rawrbox::Colorf& cl) { color = cl.pack(); }
+		[[nodiscard]] rawrbox::Colorf getColor() const { return rawrbox::Color::RGBAHex(data.x); }
+		void setColor(const rawrbox::Colorf& cl) { data.x = cl.pack(); }
 
 		[[nodiscard]] const rawrbox::Matrix4x4& getMatrix() const { return matrix; }
 		void setMatrix(const rawrbox::Matrix4x4& mtrx) { matrix = mtrx; }
 
-		[[nodiscard]] uint16_t getAtlasId() const { return static_cast<uint16_t>(extraData.w); }
-		void setAtlasId(uint16_t id) { extraData.w = static_cast<float>(id); }
+		[[nodiscard]] uint32_t getSlice() const { return data.y; }
+		void setSlice(uint32_t slice) { data.y = slice; }
 
-		[[nodiscard]] uint32_t getId() const {
-			return rawrbox::PackUtils::toRGBA(extraData.x, extraData.y, extraData.z, 1.F);
-		}
-
-		void setId(uint32_t id) {
-			auto pack = rawrbox::PackUtils::fromRGBA((id << 8) | 0xFF);
-
-			extraData.x = pack[0];
-			extraData.y = pack[1];
-			extraData.z = pack[2];
-		}
+		[[nodiscard]] uint32_t getId() const { return data.z; }
+		void setId(uint32_t id) { data.z = (id << 8) | 0xFF; }
 	};
 } // namespace rawrbox

--- a/rawrbox.render/include/rawrbox/render/models/mesh.hpp
+++ b/rawrbox.render/include/rawrbox/render/models/mesh.hpp
@@ -61,22 +61,15 @@ namespace rawrbox {
 	struct MeshData { // Aka data for vertex shader
 	public:
 		float vertexSnapPower = 0.F;
-		float billboard = 0.F;
+		uint32_t slice = 0;
+		uint32_t billboard = 0;
 
 		// Displacement ---
 		rawrbox::TextureBase* displacement = nullptr;
 		float displacementPower = 1.F;
 		// --------------
 
-		[[nodiscard]] rawrbox::Vector4f getData() const {
-			if (displacement != nullptr) {
-				return {billboard, vertexSnapPower, static_cast<float>(displacement->getTextureID()), displacementPower};
-			}
-
-			return {billboard, vertexSnapPower, 0.F, 0.F};
-		}
-
-		bool operator==(const rawrbox::MeshData& other) const { return this->vertexSnapPower == other.vertexSnapPower && this->billboard == other.billboard && this->displacement == other.displacement && this->displacementPower == other.displacementPower; }
+		bool operator==(const rawrbox::MeshData& other) const { return this->vertexSnapPower == other.vertexSnapPower && this->billboard == other.billboard && this->slice == other.slice && this->displacement == other.displacement && this->displacementPower == other.displacementPower; }
 		bool operator!=(const rawrbox::MeshData& other) const { return !operator==(other); }
 	};
 
@@ -206,24 +199,8 @@ namespace rawrbox {
 			return std::bit_cast<B*>(this->owner);
 		}
 
-		[[nodiscard]] virtual uint16_t getAtlasID(int index = -1) const {
-			if (this->vertices.empty()) return 0;
-			if (index < 0) return static_cast<uint16_t>(this->vertices.front().uv.z);
-
-			return static_cast<uint16_t>(this->vertices[std::clamp(index, 0, static_cast<int>(this->vertices.size() - 1))].uv.z);
-		}
-
-		virtual void setAtlasID(uint16_t _atlasId, int index = -1) {
-			auto vSize = static_cast<int>(this->vertices.size());
-			for (int i = 0; i < vSize; i++) {
-				if (index != -1 && i == index) {
-					this->vertices[i].setAtlasId(_atlasId);
-					break;
-				}
-
-				this->vertices[i].setAtlasId(_atlasId);
-			}
-		}
+		[[nodiscard]] virtual uint32_t getSlice() const { return this->data.slice; }
+		virtual void setSlice(uint32_t slice) { this->data.slice = slice; }
 
 		[[nodiscard]] virtual const rawrbox::TextureBase* getTexture() const { return this->textures.texture; }
 		virtual void setTexture(rawrbox::TextureBase* ptr) {
@@ -259,7 +236,7 @@ namespace rawrbox {
 		}
 
 		virtual void setBillboard(uint32_t set) {
-			this->data.billboard = static_cast<float>(set);
+			this->data.billboard = set;
 		}
 
 		virtual void setVertexSnap(float power = 2.F) {
@@ -275,9 +252,7 @@ namespace rawrbox {
 		}
 
 		[[nodiscard]] virtual uint32_t getID() const { return this->meshID; }
-		virtual void setID(uint32_t id) {
-			this->meshID = (id << 8) | 0xFF;
-		}
+		virtual void setID(uint32_t id) { this->meshID = (id << 8) | 0xFF; }
 
 		[[nodiscard]] virtual const rawrbox::Color& getColor() const { return this->color; }
 		virtual void setColor(const rawrbox::Color& _color) {

--- a/rawrbox.render/include/rawrbox/render/models/vertex.hpp
+++ b/rawrbox.render/include/rawrbox/render/models/vertex.hpp
@@ -20,11 +20,11 @@ namespace rawrbox {
 		    const rawrbox::Vector4f& _uv = {}) : position(_pos), uv(_uv) {}
 
 		void setUV(const rawrbox::Vector4f& _uv) { this->uv = _uv; }
+		void setPos(const rawrbox::Vector3f& _pos) { this->position = _pos; }
 
-		// Atlas ---
-		void setAtlasId(uint32_t _id) {
-			this->uv.z = static_cast<float>(_id);
-		}
+		// Texture array ---
+		void setSlice(uint32_t _id) { this->uv.z = static_cast<float>(_id); }
+		[[nodiscard]] uint32_t getSlice() const { return static_cast<uint16_t>(this->uv.z); }
 		// ---------------------
 
 		static std::vector<Diligent::LayoutElement> vLayout(bool instanced = false) {
@@ -40,8 +40,7 @@ namespace rawrbox {
 				v.emplace_back(4, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 3
 				v.emplace_back(5, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 4
 
-				v.emplace_back(6, 1, 4, Diligent::VT_UINT8, true, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE);    // Color
-				v.emplace_back(7, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Extra
+				v.emplace_back(6, 1, 4, Diligent::VT_UINT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Data
 			}
 
 			return v;
@@ -79,8 +78,7 @@ namespace rawrbox {
 				v.emplace_back(6, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 3
 				v.emplace_back(7, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 4
 
-				v.emplace_back(8, 1, 4, Diligent::VT_UINT8, true, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE);    // Color
-				v.emplace_back(9, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Extra
+				v.emplace_back(8, 1, 4, Diligent::VT_UINT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Data
 			}
 
 			return v;
@@ -113,8 +111,7 @@ namespace rawrbox {
 				v.emplace_back(6, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 3
 				v.emplace_back(7, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 4
 
-				v.emplace_back(8, 1, 4, Diligent::VT_UINT8, true, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE);    // Color
-				v.emplace_back(9, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Extra
+				v.emplace_back(8, 1, 4, Diligent::VT_UINT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Data
 			}
 
 			return v;
@@ -153,8 +150,7 @@ namespace rawrbox {
 				v.emplace_back(8, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 3
 				v.emplace_back(9, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Matrix - 4
 
-				v.emplace_back(10, 1, 4, Diligent::VT_UINT8, true, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE);    // Color
-				v.emplace_back(11, 1, 4, Diligent::VT_FLOAT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Extra
+				v.emplace_back(10, 1, 4, Diligent::VT_UINT32, false, Diligent::INPUT_ELEMENT_FREQUENCY_PER_INSTANCE); // Data
 			}
 
 			return v;

--- a/rawrbox.render/include/rawrbox/render/scripting/wrappers/models/mesh.hpp
+++ b/rawrbox.render/include/rawrbox/render/scripting/wrappers/models/mesh.hpp
@@ -42,8 +42,8 @@ namespace rawrbox {
 
 			    .addFunction("setTransparentBlending", &MeshC::setTransparentBlending)
 
-			    .addFunction("getAtlasID", &MeshC::getAtlasID)
-			    .addFunction("setAtlasID", &MeshC::setAtlasID)
+			    .addFunction("getSlice", &MeshC::getSlice)
+			    .addFunction("setSlice", &MeshC::setSlice)
 
 			    .addFunction("getTexture", &MeshC::getTexture)
 			    .addFunction("setTexture", &MeshC::setTexture)

--- a/rawrbox.render/include/rawrbox/render/stencil.hpp
+++ b/rawrbox.render/include/rawrbox/render/stencil.hpp
@@ -224,7 +224,7 @@ namespace rawrbox {
 		virtual void drawPolygon(const rawrbox::Polygon& poly);
 		virtual void drawTriangle(const rawrbox::Vector2f& a, const rawrbox::Vector2f& aUV, const rawrbox::Color& colA, const rawrbox::Vector2f& b, const rawrbox::Vector2f& bUV, const rawrbox::Color& colB, const rawrbox::Vector2f& c, const rawrbox::Vector2f& cUV, const rawrbox::Color& colC);
 		virtual void drawBox(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::Color& col = rawrbox::Colors::White());
-		virtual void drawTexture(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::TextureBase& tex, const rawrbox::Color& col = rawrbox::Colors::White(), const rawrbox::Vector2f& uvStart = {0, 0}, const rawrbox::Vector2f& uvEnd = {1, 1}, uint32_t atlasId = 0);
+		virtual void drawTexture(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::TextureBase& tex, const rawrbox::Color& col = rawrbox::Colors::White(), const rawrbox::Vector2f& uvStart = {0, 0}, const rawrbox::Vector2f& uvEnd = {1, 1}, int slice = -1);
 		virtual void drawCircle(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::Color& col = rawrbox::Colors::White(), size_t roundness = 32, float angleStart = 0.F, float angleEnd = 360.F);
 		virtual void drawLine(const rawrbox::Vector2& from, const rawrbox::Vector2& to, const rawrbox::Color& col = rawrbox::Colors::White());
 		virtual void drawText(const std::string& text, const rawrbox::Vector2f& pos, const rawrbox::Color& col = rawrbox::Colors::White(), const rawrbox::Color& bgCol = rawrbox::Colors::Transparent());

--- a/rawrbox.render/include/rawrbox/render/textures/animated.hpp
+++ b/rawrbox.render/include/rawrbox/render/textures/animated.hpp
@@ -18,10 +18,9 @@ namespace rawrbox {
 		std::vector<rawrbox::Frame> _frames = {};
 		std::filesystem::path _filePath = "";
 
-		int _currentFrame = 0;
-
 		bool _loop = true;
 		bool _pause = false;
+		bool _textureArray = false;
 
 		uint64_t _cooldown = 0;
 		float _speed = 1.F;
@@ -41,16 +40,20 @@ namespace rawrbox {
 		virtual void reset();
 		// --------------------
 
-		// ------UTILS
-		virtual bool getLoop();
+		// UTILS -----------
+		[[nodiscard]] virtual bool getLoop() const;
 		virtual void setLoop(bool loop);
-		virtual bool getPaused();
+		[[nodiscard]] virtual bool getPaused() const;
 		virtual void setPaused(bool paused);
-		virtual float getSpeed();
+		[[nodiscard]] virtual float getSpeed() const;
 		virtual void setSpeed(float speed);
+
+		[[nodiscard]] virtual uint32_t total() const;
+
+		[[nodiscard]] uint32_t getSlice() const override;
 		// --------------------
 
-		// ------RENDER
+		// RENDER ------
 		void upload(Diligent::TEXTURE_FORMAT format = Diligent::TEXTURE_FORMAT::TEX_FORMAT_UNKNOWN, bool dynamic = false) override;
 		// --------------------
 

--- a/rawrbox.render/include/rawrbox/render/textures/base.hpp
+++ b/rawrbox.render/include/rawrbox/render/textures/base.hpp
@@ -25,8 +25,10 @@ namespace rawrbox {
 		rawrbox::Vector2u _size = {};
 
 		int _channels = 0;
+
 		uint32_t _textureID = 0; // Default to missing texture, it's always reserved to 0
 		uint32_t _depthTextureID = 0;
+		uint32_t _slice = 0;
 
 		std::vector<uint8_t> _pixels = {};
 
@@ -82,6 +84,9 @@ namespace rawrbox {
 		virtual void setName(const std::string& name);
 
 		virtual void setSRGB(bool set);
+
+		virtual void setSlice(uint32_t id);
+		[[nodiscard]] virtual uint32_t getSlice() const;
 		// -----
 
 		virtual void upload(Diligent::TEXTURE_FORMAT format = Diligent::TEXTURE_FORMAT::TEX_FORMAT_UNKNOWN, bool dynamic = false);

--- a/rawrbox.render/src/scripting/wrappers/models/instance.cpp
+++ b/rawrbox.render/src/scripting/wrappers/models/instance.cpp
@@ -14,8 +14,8 @@ namespace rawrbox {
 		    .addFunction("getMatrix", &Instance::getMatrix)
 		    .addFunction("setMatrix", &Instance::setMatrix)
 
-		    .addFunction("getAtlasId", &Instance::getAtlasId)
-		    .addFunction("setAtlasId", &Instance::setAtlasId)
+		    .addFunction("getSlice", &Instance::getSlice)
+		    .addFunction("setSlice", &Instance::setSlice)
 
 		    .addFunction("getId", &Instance::getId)
 		    .addFunction("setId", &Instance::setId)

--- a/rawrbox.render/src/scripting/wrappers/textures/base.cpp
+++ b/rawrbox.render/src/scripting/wrappers/textures/base.cpp
@@ -10,6 +10,19 @@ namespace rawrbox {
 		    // UTILS----
 		    .addFunction("hasTransparency", &rawrbox::TextureBase::hasTransparency)
 		    .addFunction("getSize", &rawrbox::TextureBase::getSize)
+
+		    .addFunction("getTextureID", &rawrbox::TextureBase::getTextureID)
+		    .addFunction("getDepthTextureID", &rawrbox::TextureBase::getDepthTextureID)
+
+		    .addFunction("setSlice", &rawrbox::TextureBase::setSlice)
+		    .addFunction("getSlice", &rawrbox::TextureBase::getSlice)
+
+		    .addFunction("getChannels", &rawrbox::TextureBase::getChannels)
+
+		    .addFunction("setName", &rawrbox::TextureBase::setName)
+		    .addFunction("getName", &rawrbox::TextureBase::getName)
+
+		    .addFunction("isRegistered", &rawrbox::TextureBase::isRegistered)
 		    .addFunction("isValid", &rawrbox::TextureBase::isValid)
 		    // -----
 

--- a/rawrbox.render/src/stencil.cpp
+++ b/rawrbox.render/src/stencil.cpp
@@ -184,7 +184,7 @@ namespace rawrbox {
 		}
 	}
 
-	void Stencil::drawTexture(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::TextureBase& tex, const rawrbox::Color& col, const rawrbox::Vector2f& uvStart, const rawrbox::Vector2f& uvEnd, uint32_t atlas) {
+	void Stencil::drawTexture(const rawrbox::Vector2f& pos, const rawrbox::Vector2f& size, const rawrbox::TextureBase& tex, const rawrbox::Color& col, const rawrbox::Vector2f& uvStart, const rawrbox::Vector2f& uvEnd, int slice) {
 		if (col.invisible()) return;
 
 		// Setup --------
@@ -192,7 +192,7 @@ namespace rawrbox {
 		// ----
 
 		auto textureID = tex.getTextureID();
-		auto a = static_cast<float>(atlas);
+		auto a = slice == -1 ? tex.getSlice() : static_cast<float>(slice);
 
 		this->pushVertice(textureID, {pos.x, pos.y}, {uvStart.x, uvStart.y, a}, col);
 		this->pushVertice(textureID, {pos.x, pos.y + size.y}, {uvStart.x, uvEnd.y, a}, col);

--- a/rawrbox.render/src/textures/animated.cpp
+++ b/rawrbox.render/src/textures/animated.cpp
@@ -22,7 +22,7 @@ namespace rawrbox {
 
 		Diligent::TextureSubResData SubresData;
 		SubresData.Stride = this->_size.x * this->_channels;
-		SubresData.pData = this->_frames.empty() ? this->_pixels.data() : this->_frames[this->_currentFrame].pixels.data();
+		SubresData.pData = this->_frames.empty() ? this->_pixels.data() : this->_frames[this->_slice].pixels.data();
 
 		rawrbox::BarrierUtils::barrier({{this->_tex, Diligent::RESOURCE_STATE_SHADER_RESOURCE, Diligent::RESOURCE_STATE_COPY_DEST, Diligent::STATE_TRANSITION_FLAG_UPDATE_STATE}});
 		context->UpdateTexture(this->_tex, 0, 0, UpdateBox, SubresData, Diligent::RESOURCE_STATE_TRANSITION_MODE_VERIFY, Diligent::RESOURCE_STATE_TRANSITION_MODE_VERIFY);
@@ -34,7 +34,7 @@ namespace rawrbox {
 		if (this->_failedToLoad || this->_handle == nullptr) return; // Not bound
 		if (this->_pause || this->_cooldown >= rawrbox::TimeUtils::curtime()) return;
 
-		if (static_cast<size_t>(this->_currentFrame) >= this->_frames.size()) {
+		if (static_cast<size_t>(this->_slice) >= this->_frames.size()) {
 			this->onEnd();
 
 			if (!this->_loop) {
@@ -42,46 +42,102 @@ namespace rawrbox {
 				return;
 			}
 
-			this->_currentFrame = 0;
+			this->_slice = 0;
 		}
 
-		this->_cooldown = static_cast<int64_t>(this->_frames[this->_currentFrame].delay / this->_speed) + rawrbox::TimeUtils::curtime();
-		this->internalUpdate();
+		this->_cooldown = static_cast<int64_t>(this->_frames[this->_slice].delay / this->_speed) + rawrbox::TimeUtils::curtime();
+		if (!this->_textureArray) this->internalUpdate(); // Handled by shader / slice instead
 
-		this->_currentFrame++;
+		this->_slice++;
 	}
 
 	void TextureAnimatedBase::reset() {
 		if (this->_failedToLoad || this->_handle == nullptr) return; // Not bound
 
-		this->_cooldown = 0;
 		this->_pause = false;
-		this->_currentFrame = 0;
-		this->update();
+		this->_cooldown = 0;
+		this->_slice = 0;
+
+		if (!this->_textureArray) this->internalUpdate(); // Handled by shader instead
 	}
 	// --------------------
 
 	// UTILS ------
-	bool TextureAnimatedBase::getPaused() { return this->_pause; }
+	bool TextureAnimatedBase::getPaused() const { return this->_pause; }
 	void TextureAnimatedBase::setPaused(bool paused) {
 		this->_pause = paused;
 	}
 
-	bool TextureAnimatedBase::getLoop() { return this->_loop; }
+	bool TextureAnimatedBase::getLoop() const { return this->_loop; }
 	void TextureAnimatedBase::setLoop(bool loop) {
 		this->_loop = loop;
 	}
 
-	float TextureAnimatedBase::getSpeed() { return this->_speed; }
+	float TextureAnimatedBase::getSpeed() const { return this->_speed; }
 	void TextureAnimatedBase::setSpeed(float speed) {
 		this->_speed = speed;
+	}
+
+	uint32_t TextureAnimatedBase::total() const { return static_cast<uint32_t>(this->_frames.size()); }
+	uint32_t TextureAnimatedBase::getSlice() const {
+		return this->_textureArray ? this->_slice : 0;
 	}
 	// --------------------
 
 	// RENDER ------
 	void TextureAnimatedBase::upload(Diligent::TEXTURE_FORMAT format, bool /*dynamic*/) {
 		if (this->_failedToLoad || this->_handle != nullptr) return; // Failed texture is already bound, so skip it
-		rawrbox::TextureBase::upload(format, true);
+
+		this->_textureArray = this->_size.x <= 1024 && this->_size.y <= 1024 && this->total() <= 256;
+		if (!this->_textureArray) {
+			rawrbox::TextureBase::upload(format, true);
+			return;
+		}
+
+		// Try to determine texture format
+		this->tryGetFormatChannels(format, this->_channels);
+		// --------------------------------
+
+		Diligent::TextureDesc desc;
+		desc.Type = Diligent::RESOURCE_DIM_TEX_2D_ARRAY;
+		desc.BindFlags = Diligent::BIND_SHADER_RESOURCE;
+		desc.Usage = Diligent::USAGE_IMMUTABLE;
+		desc.CPUAccessFlags = Diligent::CPU_ACCESS_NONE;
+		desc.Width = this->_size.x;
+		desc.Height = this->_size.y;
+		desc.MipLevels = 1;
+		desc.Format = format;
+		// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+		desc.ArraySize = static_cast<uint32_t>(this->_frames.size());
+		// NOLINTEND(cppcoreguidelines-pro-type-union-access)
+		desc.Name = this->_name.c_str();
+
+		// NOLINTBEGIN(cppcoreguidelines-pro-type-union-access)
+		std::vector<Diligent::TextureSubResData> subresData(desc.ArraySize);
+		// NOLINTEND(cppcoreguidelines-pro-type-union-access)
+
+		for (uint32_t slice = 0; slice < subresData.size(); slice++) {
+			auto& res = subresData[slice];
+
+			res.pData = this->_frames[slice].pixels.data();
+			res.Stride = desc.Width * this->_channels;
+		}
+
+		Diligent::TextureData data;
+		data.pSubResources = subresData.data();
+		data.NumSubresources = static_cast<uint32_t>(subresData.size());
+
+		rawrbox::RENDERER->device()->CreateTexture(desc, &data, &this->_tex);
+		if (this->_tex == nullptr) throw this->_logger->error("Failed to create texture '{}'", this->_name);
+
+		// Get handles --
+		this->_handle = this->_tex->GetDefaultView(Diligent::TEXTURE_VIEW_SHADER_RESOURCE);
+		// -------
+
+		rawrbox::runOnRenderThread([this]() {
+			rawrbox::BarrierUtils::barrier({{this->_tex, Diligent::RESOURCE_STATE_UNKNOWN, Diligent::RESOURCE_STATE_SHADER_RESOURCE, Diligent::STATE_TRANSITION_FLAG_UPDATE_STATE}});
+			rawrbox::BindlessManager::registerTexture(*this);
+		});
 	}
 	// --------------------
 

--- a/rawrbox.render/src/textures/base.cpp
+++ b/rawrbox.render/src/textures/base.cpp
@@ -112,6 +112,9 @@ namespace rawrbox {
 	void TextureBase::setName(const std::string& name) { this->_name = fmt::format("RawrBox::Texture::{}", name); }
 
 	void TextureBase::setSRGB(bool set) { this->_sRGB = set; }
+
+	void TextureBase::setSlice(uint32_t id) { this->_slice = id; }
+	uint32_t TextureBase::getSlice() const { return this->_slice; }
 	// ----
 
 	void TextureBase::upload(Diligent::TEXTURE_FORMAT format, bool dynamic) {

--- a/rawrbox.webm/include/rawrbox/webm/textures/webm.hpp
+++ b/rawrbox.webm/include/rawrbox/webm/textures/webm.hpp
@@ -30,13 +30,13 @@ namespace rawrbox {
 		void seek(uint64_t timeMS);
 		void reset() override;
 
-		bool getLoop() override;
+		[[nodiscard]] bool getLoop() const override;
 		void setLoop(bool loop) override;
 
-		bool getPaused() override;
+		[[nodiscard]] bool getPaused() const override;
 		void setPaused(bool paused) override;
 
-		float getSpeed() override;
+		[[nodiscard]] float getSpeed() const override;
 		void setSpeed(float speed) override;
 		// ----
 

--- a/rawrbox.webm/src/textures/webm.cpp
+++ b/rawrbox.webm/src/textures/webm.cpp
@@ -67,7 +67,7 @@ namespace rawrbox {
 		this->_cooldown = rawrbox::TimeUtils::curtime() + 20;
 	}
 
-	bool TextureWEBM::getLoop() {
+	bool TextureWEBM::getLoop() const {
 		if (this->_webm == nullptr) return false;
 		return this->_webm->getLoop();
 	}
@@ -77,7 +77,7 @@ namespace rawrbox {
 		this->_webm->setLoop(loop);
 	}
 
-	bool TextureWEBM::getPaused() {
+	bool TextureWEBM::getPaused() const {
 		if (this->_webm == nullptr) return false;
 		return this->_webm->getPaused();
 	}
@@ -87,7 +87,7 @@ namespace rawrbox {
 		this->_webm->setPaused(paused);
 	}
 
-	float TextureWEBM::getSpeed() {
+	float TextureWEBM::getSpeed() const {
 		throw std::runtime_error("[RawrBox-TextureWEBM] Not supported");
 	}
 

--- a/samples/001-stencil/src/game.cpp
+++ b/samples/001-stencil/src/game.cpp
@@ -113,7 +113,7 @@ namespace stencil {
 		std::random_device prng;
 		std::uniform_int_distribution<uint16_t> dist(0, 4);
 		for (auto& vertice : mesh.vertices) {
-			vertice.setAtlasId(dist(prng));
+			vertice.setSlice(dist(prng));
 		}
 
 		this->_model->addMesh(mesh);


### PR DESCRIPTION
- Rename atlasID to slice
- Animated textures now use slices (if they are small enough)
- Some vertex optimizations
- Some instancing optimizations

![](https://i.rawr.dev/F4BOZNAdH0.gif)

Closes #155 