### PR TITLE
Fix Lunarg Vulkan-SDK

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,14 +25,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
 
-      - name: Initial Setup
-        run: |
-          sudo apt update
-          sudo apt install -y git wget
-
-          wget -qO- https://packages.lunarg.com/lunarg-signing-key-pub.asc | sudo tee /etc/apt/trusted.gpg.d/lunarg.asc
-          sudo wget -qO /etc/apt/sources.list.d/lunarg-vulkan-noble.list http://packages.lunarg.com/vulkan/lunarg-vulkan-noble.list
-
       - name: Install dependencies
         run: |
           sudo apt update


### PR DESCRIPTION
Moved dependency for Lunarg Vulkan-SDK into [base image
](https://github.com/D3lta/action-runner-container/blob/main/Dockerfile#L45-L46) to create an uniform ephemeral container

To replace the Ubuntu build-in vulkan-sdk from 2024-04-17
https://answers.launchpad.net/ubuntu/noble/amd64/libvulkan-dev

(For future reference)
If we want to use Github hosted we might have to add this back depending on what versions/builds Github uses.